### PR TITLE
Added a method check within the create post endpoint

### DIFF
--- a/Bookworm-Society-API/Endpoints/PostEndpoints.cs
+++ b/Bookworm-Society-API/Endpoints/PostEndpoints.cs
@@ -31,6 +31,10 @@ namespace Bookworm_Society_API.Endpoints
                 {
                     return Results.NotFound(result.Message);
                 }
+                if (result.ErrorType == ErrorType.Conflict)
+                {
+                    return Results.Conflict(result.Message);
+                }
 
                 return Results.Ok(result.Data);
             });

--- a/Bookworm-Society-API/Interfaces/IPostRepository.cs
+++ b/Bookworm-Society-API/Interfaces/IPostRepository.cs
@@ -9,5 +9,6 @@ namespace Bookworm_Society_API.Interfaces
         Task<Post> CreatePostAsync(Post post);
         Task<Post> UpdatePostAsync(Post post, int postId);
         Task<Post> DeletePostAsync(int postId);
+        Task<bool> IsUserAllowedToPost(int bookClubId, int userId);
     }
 }

--- a/Bookworm-Society-API/Repositories/PostRepository.cs
+++ b/Bookworm-Society-API/Repositories/PostRepository.cs
@@ -61,5 +61,19 @@ namespace Bookworm_Society_API.Repositories
             await dbContext.SaveChangesAsync();
             return postToDelete;
         }
+
+        public async Task<bool> IsUserAllowedToPost(int bookClubId, int  userId)
+        {
+            var bookClub = await dbContext.BookClubs
+                .Include(bc => bc.Members)
+                .Include(bc => bc.Host)
+                .SingleOrDefaultAsync(bc => bc.Id == bookClubId);
+
+            bool isHost = bookClub.Host.Id == userId;
+            bool isMember = bookClub.Members?.Any(m => m.Id == userId) == true;
+
+            return isHost || isMember;
+        }
+
     }
 }

--- a/Bookworm-Society-API/Services/PostService.cs
+++ b/Bookworm-Society-API/Services/PostService.cs
@@ -2,6 +2,7 @@
 using Bookworm_Society_API.DTOs;
 using Bookworm_Society_API.Interfaces;
 using Bookworm_Society_API.Models;
+using Bookworm_Society_API.Repositories;
 using Bookworm_Society_API.Result;
 using Microsoft.EntityFrameworkCore;
 
@@ -62,6 +63,10 @@ namespace Bookworm_Society_API.Services
             {
                 return Result<Post>.FailureResult($"No book club exist with the following id: {post.BookClubId}", ErrorType.NotFound);
             }
+            if (!await _postRepository.IsUserAllowedToPost(post.BookClubId, post.UserId))
+            {
+                return Result<Post>.FailureResult("User is not a member or host of this book club.", ErrorType.Conflict);
+            }
 
             Post postObj = new()
             {
@@ -78,15 +83,6 @@ namespace Bookworm_Society_API.Services
         //Update post 
         public async Task<Result<Post>> UpdatePostAsync(Post post, int postId)
         {
-           /* if (!await _baseRepository.UserExistsAsync(post.UserId))
-            {
-                return Result<Post>.FailureResult($"No user exist with the following id: {post.UserId}", ErrorType.NotFound);
-            }
-
-            if (!await _baseRepository.BookClubExistsAsync(post.BookClubId))
-            {
-                return Result<Post>.FailureResult($"No book club exist with the following id: {post.BookClubId}", ErrorType.NotFound);
-            }*/
 
             var postToUpdate = await _postRepository.UpdatePostAsync(post, postId);
 


### PR DESCRIPTION
﻿## Detailed Description
<!--- Explain **what** was changed and **why** -->
<!--- Why is this change required? What problem does it solve? -->
Added a method that checks if a user is in the club before moving forward with creating a post.

## How to Test
<!--- Step-by-step instructions for testing your changes. -->
<!--- Include any necessary setup steps, commands to run, or test cases. -->
1.  use the get single bookclub endpoint so you can grab the member array from a book club. 
2. Go to the create post endpoint and enter the bookclub id and make sure to pass a userId that isn't in that club. 
3. You should get a conflict error saying that you are aren't in the club.  


## Screenshots (if applicable)

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x ] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation

## 💬 Additional Notes
<!--- Add any other context, discussions, or considerations regarding this PR. -->
