### PR TITLE
Voting session endpoints

### DIFF
--- a/Bookworm-Society-API/DTOs/CreateVoteDTO.cs
+++ b/Bookworm-Society-API/DTOs/CreateVoteDTO.cs
@@ -1,0 +1,11 @@
+﻿using Bookworm_Society_API.Models;
+
+namespace Bookworm_Society_API.DTOs
+{
+    public class CreateVoteDTO
+    {
+        public int UserId { get; set; }
+        public int BookId { get; set; }
+        public int VotingSessionId { get; set; }
+    }
+}

--- a/Bookworm-Society-API/DTOs/CreateVotingSessionDTO.cs
+++ b/Bookworm-Society-API/DTOs/CreateVotingSessionDTO.cs
@@ -1,0 +1,9 @@
+﻿namespace Bookworm_Society_API.DTOs
+{
+    public class CreateVotingSessionDTO
+    {
+        public DateTime VotingEndDate { get; set; }
+        public int BookClubId { get; set; }
+        public List<int> BookIds { get; set; }
+    }
+}

--- a/Bookworm-Society-API/DTOs/CreateVotingSessionRequestDTO.cs
+++ b/Bookworm-Society-API/DTOs/CreateVotingSessionRequestDTO.cs
@@ -1,0 +1,10 @@
+﻿namespace Bookworm_Society_API.DTOs
+{
+    public class CreateVotingSessionRequestDTO
+    {
+        public int UserId { get; set; }
+        public int BookClubId { get; set; }
+        public List<int> BookIds { get; set; }
+    }
+
+}

--- a/Bookworm-Society-API/DTOs/VotingSessionDTO.cs
+++ b/Bookworm-Society-API/DTOs/VotingSessionDTO.cs
@@ -1,0 +1,6 @@
+﻿namespace Bookworm_Society_API.DTOs
+{
+    public class VotingSessionDTO
+    {
+    }
+}

--- a/Bookworm-Society-API/Data/Bookworm-SocietyDbContext.cs
+++ b/Bookworm-Society-API/Data/Bookworm-SocietyDbContext.cs
@@ -13,6 +13,7 @@ namespace Bookworm_Society_API.Data
         public DbSet<Comment> Comments { get; set; }
         public DbSet<BookClub> BookClubs { get; set; }
         public DbSet<Book> Books { get; set; }
+        public DbSet<Vote> Votes { get; set; }
 
         public Bookworm_SocietyDbContext(DbContextOptions<Bookworm_SocietyDbContext> context) : base(context) 
         {
@@ -69,6 +70,8 @@ namespace Bookworm_Society_API.Data
             modelBuilder.Entity<BookClub>().HasData(BookClubData.BookClubs);
 
             modelBuilder.Entity<Book>().HasData(BookData.Books);
+
+            modelBuilder.Entity<Vote>().HasData(VoteData.Votes);
 
         }
     }

--- a/Bookworm-Society-API/Endpoints/VoteEndpoints.cs
+++ b/Bookworm-Society-API/Endpoints/VoteEndpoints.cs
@@ -20,10 +20,10 @@ namespace Bookworm_Society_API.Endpoints
                     return Results.NotFound(result.Message);
                 }
 
-                /*if (result.ErrorType == ErrorType.Conflict)
+                if (result.ErrorType == ErrorType.Conflict)
                 {
                     return Results.Conflict(result.Message);
-                }*/
+                }
 
                 return Results.Ok(result.Data);
             });

--- a/Bookworm-Society-API/Endpoints/VoteEndpoints.cs
+++ b/Bookworm-Society-API/Endpoints/VoteEndpoints.cs
@@ -1,4 +1,7 @@
-﻿using Bookworm_Society_API.Models;
+﻿using Bookworm_Society_API.DTOs;
+using Bookworm_Society_API.Interfaces;
+using Bookworm_Society_API.Models;
+using Bookworm_Society_API.Result;
 
 namespace Bookworm_Society_API.Endpoints
 {
@@ -6,7 +9,24 @@ namespace Bookworm_Society_API.Endpoints
     {
         public static void MapVoteEndpoints(this IEndpointRouteBuilder routes)
         {
-            var group = routes.MapGroup("").WithTags(nameof(Vote));
+            var group = routes.MapGroup("votes").WithTags(nameof(Vote));
+
+            group.MapPost("/", async (IVoteService voteService, CreateVoteDTO voteDTO) =>
+            {
+                var result = await voteService.CreateVote(voteDTO);
+
+                if (result.ErrorType == ErrorType.NotFound)
+                {
+                    return Results.NotFound(result.Message);
+                }
+
+                /*if (result.ErrorType == ErrorType.Conflict)
+                {
+                    return Results.Conflict(result.Message);
+                }*/
+
+                return Results.Ok(result.Data);
+            });
         }
     }
 }

--- a/Bookworm-Society-API/Endpoints/VotingSessionEndpoints.cs
+++ b/Bookworm-Society-API/Endpoints/VotingSessionEndpoints.cs
@@ -19,9 +19,14 @@ namespace Bookworm_Society_API.Endpoints
                     return Results.NotFound(result.Message);
                 }
 
+                if (result.ErrorType == ErrorType.Conflict)
+                {
+                    return Results.Conflict(result.Message);
+                }
+
                 if (result.Data == null)
                 {
-                    return Results.Ok(new { message = result.Message });
+                    return Results.Ok(result.Message);
                 }
 
                 return Results.Ok(result.Data);

--- a/Bookworm-Society-API/Endpoints/VotingSessionEndpoints.cs
+++ b/Bookworm-Society-API/Endpoints/VotingSessionEndpoints.cs
@@ -1,4 +1,5 @@
-﻿using Bookworm_Society_API.Interfaces;
+﻿using Bookworm_Society_API.DTOs;
+using Bookworm_Society_API.Interfaces;
 using Bookworm_Society_API.Models;
 using Bookworm_Society_API.Result;
 
@@ -27,6 +28,23 @@ namespace Bookworm_Society_API.Endpoints
                 if (result.Data == null)
                 {
                     return Results.Ok(result.Message);
+                }
+
+                return Results.Ok(result.Data);
+            });
+
+            group.MapPost("/", async (IVotingSessionService votingSessionService, CreateVotingSessionDTO votingSessionDTO, int userId) =>
+            {
+                var result = await votingSessionService.CreateVotingSession(votingSessionDTO, userId);
+
+                if (result.ErrorType == ErrorType.NotFound)
+                {
+                    return Results.NotFound(result.Message);
+                }
+
+                if (result.ErrorType == ErrorType.Conflict)
+                {
+                    return Results.Conflict(result.Message);
                 }
 
                 return Results.Ok(result.Data);

--- a/Bookworm-Society-API/Endpoints/VotingSessionEndpoints.cs
+++ b/Bookworm-Society-API/Endpoints/VotingSessionEndpoints.cs
@@ -1,4 +1,6 @@
-﻿using Bookworm_Society_API.Models;
+﻿using Bookworm_Society_API.Interfaces;
+using Bookworm_Society_API.Models;
+using Bookworm_Society_API.Result;
 
 namespace Bookworm_Society_API.Endpoints
 {
@@ -6,7 +8,24 @@ namespace Bookworm_Society_API.Endpoints
     {
         public static void MapVotingSessionEndpoints(this IEndpointRouteBuilder routes)
         {
-            var group = routes.MapGroup("").WithTags(nameof(VotingSession));
+            var group = routes.MapGroup("votingsessions").WithTags(nameof(VotingSession));
+
+            group.MapGet("/bookclubs/{bookClubId}", async (IVotingSessionService votingSessionService, int bookClubId, int userId) =>
+            {
+                var result = await votingSessionService.GetLatestVotingSessionAsync(bookClubId, userId);
+
+                if (result.ErrorType == ErrorType.NotFound)
+                {
+                    return Results.NotFound(result.Message);
+                }
+
+                if (result.Data == null)
+                {
+                    return Results.Ok(new { message = result.Message });
+                }
+
+                return Results.Ok(result.Data);
+            });
         }
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVoteRepository.cs
+++ b/Bookworm-Society-API/Interfaces/IVoteRepository.cs
@@ -1,6 +1,11 @@
-﻿namespace Bookworm_Society_API.Interfaces
+﻿using Bookworm_Society_API.Models;
+
+namespace Bookworm_Society_API.Interfaces
 {
     public interface IVoteRepository
     {
+        Task<Vote> CreateVote(Vote vote);
+        Task<bool> VotingSessionExistsAsync(int votingSessionId);
+        Task<VotingSession> GetSingleVotingSession(int votingSessionId);
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVoteService.cs
+++ b/Bookworm-Society-API/Interfaces/IVoteService.cs
@@ -6,6 +6,6 @@ namespace Bookworm_Society_API.Interfaces
 {
     public interface IVoteService
     {
-        Task<Result<Vote>> CreateVote(CreateVoteDTO voteDTO);
+        Task<Result<object>> CreateVote(CreateVoteDTO voteDTO);
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVoteService.cs
+++ b/Bookworm-Society-API/Interfaces/IVoteService.cs
@@ -1,6 +1,11 @@
-﻿namespace Bookworm_Society_API.Interfaces
+﻿using Bookworm_Society_API.DTOs;
+using Bookworm_Society_API.Models;
+using Bookworm_Society_API.Result;
+
+namespace Bookworm_Society_API.Interfaces
 {
     public interface IVoteService
     {
+        Task<Result<Vote>> CreateVote(CreateVoteDTO voteDTO);
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
+++ b/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
@@ -7,6 +7,8 @@ namespace Bookworm_Society_API.Interfaces
     {
         Task<VotingSession> GetLatestVotingSessionAsync(int bookClubId, int userId);
         Task<bool> IsUserAllowedToVote(int bookClubId, int userId);
-        Task<VotingSession> CreateVotingSession(int userId, int bookClubId, List<int> bookIds);
+        Task<VotingSession> CreateVotingSession(VotingSession votingSession);
+
+        Task<List<Book>> GetBooksByIdsAsync(List<int> bookIds);
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
+++ b/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
@@ -1,6 +1,11 @@
-﻿namespace Bookworm_Society_API.Interfaces
+﻿using Bookworm_Society_API.Models;
+using Bookworm_Society_API.Result;
+
+namespace Bookworm_Society_API.Interfaces
 {
     public interface IVotingSessionRepository
     {
+        Task<VotingSession> GetLatestVotingSessionAsync(int bookClubId, int userId);
+        Task<VotingSession> CreateVotingSession(int userId, int bookClubId, List<int> bookIds);
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
+++ b/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
@@ -6,6 +6,7 @@ namespace Bookworm_Society_API.Interfaces
     public interface IVotingSessionRepository
     {
         Task<VotingSession> GetLatestVotingSessionAsync(int bookClubId, int userId);
+        Task<bool> IsUserAllowedToVote(int bookClubId, int userId);
         Task<VotingSession> CreateVotingSession(int userId, int bookClubId, List<int> bookIds);
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
+++ b/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
@@ -10,5 +10,9 @@ namespace Bookworm_Society_API.Interfaces
         Task<VotingSession> CreateVotingSession(VotingSession votingSession);
 
         Task<List<Book>> GetBooksByIdsAsync(List<int> bookIds);
+        Task<List<VotingSession>> GetActiveVotingSessions(CancellationToken cancellationToken);
+        Task<int> CalculateWinningBook(int votingSessionId);
+
+        Task FinalizeVotingSessionAsync(int votingSessionId, CancellationToken cancellationToken);
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
+++ b/Bookworm-Society-API/Interfaces/IVotingSessionRepository.cs
@@ -11,7 +11,7 @@ namespace Bookworm_Society_API.Interfaces
 
         Task<List<Book>> GetBooksByIdsAsync(List<int> bookIds);
         Task<List<VotingSession>> GetActiveVotingSessions(CancellationToken cancellationToken);
-        Task<int> CalculateWinningBook(int votingSessionId);
+        Task<int> CalculateWinningBook(List<Vote> votes);
 
         Task FinalizeVotingSessionAsync(int votingSessionId, CancellationToken cancellationToken);
     }

--- a/Bookworm-Society-API/Interfaces/IVotingSessionService.cs
+++ b/Bookworm-Society-API/Interfaces/IVotingSessionService.cs
@@ -1,4 +1,5 @@
-﻿using Bookworm_Society_API.Models;
+﻿using Bookworm_Society_API.DTOs;
+using Bookworm_Society_API.Models;
 using Bookworm_Society_API.Result;
 
 namespace Bookworm_Society_API.Interfaces
@@ -6,7 +7,7 @@ namespace Bookworm_Society_API.Interfaces
     public interface IVotingSessionService
     {
         Task<Result<object?>> GetLatestVotingSessionAsync(int bookClubId, int userId);
-        Task<Result<VotingSession>> CreateVotingSession(int userId, int bookClubId, List<int> bookIds);
+        Task<Result<VotingSession>> CreateVotingSession(CreateVotingSessionDTO votingSessionDTO, int userId);
 
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVotingSessionService.cs
+++ b/Bookworm-Society-API/Interfaces/IVotingSessionService.cs
@@ -8,6 +8,6 @@ namespace Bookworm_Society_API.Interfaces
     {
         Task<Result<object?>> GetLatestVotingSessionAsync(int bookClubId, int userId);
         Task<Result<VotingSession>> CreateVotingSession(CreateVotingSessionDTO votingSessionDTO, int userId);
-
+        Task CheckAndUpdateVotingSessionAsync(CancellationToken cancellationToken);
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVotingSessionService.cs
+++ b/Bookworm-Society-API/Interfaces/IVotingSessionService.cs
@@ -1,6 +1,12 @@
-﻿namespace Bookworm_Society_API.Interfaces
+﻿using Bookworm_Society_API.Models;
+using Bookworm_Society_API.Result;
+
+namespace Bookworm_Society_API.Interfaces
 {
     public interface IVotingSessionService
     {
+        Task<Result<VotingSession?>> GetLatestVotingSessionAsync(int bookClubId, int userId);
+        Task<Result<VotingSession>> CreateVotingSession(int userId, int bookClubId, List<int> bookIds);
+
     }
 }

--- a/Bookworm-Society-API/Interfaces/IVotingSessionService.cs
+++ b/Bookworm-Society-API/Interfaces/IVotingSessionService.cs
@@ -5,7 +5,7 @@ namespace Bookworm_Society_API.Interfaces
 {
     public interface IVotingSessionService
     {
-        Task<Result<VotingSession?>> GetLatestVotingSessionAsync(int bookClubId, int userId);
+        Task<Result<object?>> GetLatestVotingSessionAsync(int bookClubId, int userId);
         Task<Result<VotingSession>> CreateVotingSession(int userId, int bookClubId, List<int> bookIds);
 
     }

--- a/Bookworm-Society-API/Migrations/20241203011946_AddVoteInMyDbContext.Designer.cs
+++ b/Bookworm-Society-API/Migrations/20241203011946_AddVoteInMyDbContext.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Bookworm_Society_API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Bookworm_Society_API.Migrations
 {
     [DbContext(typeof(Bookworm_SocietyDbContext))]
-    partial class Bookworm_SocietyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241203011946_AddVoteInMyDbContext")]
+    partial class AddVoteInMyDbContext
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Bookworm-Society-API/Migrations/20241203011946_AddVoteInMyDbContext.cs
+++ b/Bookworm-Society-API/Migrations/20241203011946_AddVoteInMyDbContext.cs
@@ -1,0 +1,234 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Bookworm_Society_API.Migrations
+{
+    public partial class AddVoteInMyDbContext : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Vote_Books_BookId",
+                table: "Vote");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Vote_Users_UserId",
+                table: "Vote");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Vote_VotingSessions_VotingSessionId",
+                table: "Vote");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Vote",
+                table: "Vote");
+
+            migrationBuilder.RenameTable(
+                name: "Vote",
+                newName: "Votes");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Vote_VotingSessionId",
+                table: "Votes",
+                newName: "IX_Votes_VotingSessionId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Vote_UserId",
+                table: "Votes",
+                newName: "IX_Votes_UserId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Vote_BookId",
+                table: "Votes",
+                newName: "IX_Votes_BookId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Votes",
+                table: "Votes",
+                column: "Id");
+
+            migrationBuilder.InsertData(
+                table: "Votes",
+                columns: new[] { "Id", "BookId", "UserId", "VotingSessionId" },
+                values: new object[,]
+                {
+                    { 1, 101, 1, 1 },
+                    { 2, 102, 2, 1 },
+                    { 3, 103, 3, 1 },
+                    { 4, 104, 2, 2 },
+                    { 5, 105, 4, 2 },
+                    { 6, 106, 5, 2 },
+                    { 7, 107, 3, 3 },
+                    { 8, 108, 6, 3 },
+                    { 9, 109, 4, 4 },
+                    { 10, 110, 7, 4 },
+                    { 11, 111, 5, 5 },
+                    { 12, 112, 8, 5 },
+                    { 13, 113, 6, 6 },
+                    { 14, 114, 9, 6 }
+                });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Votes_Books_BookId",
+                table: "Votes",
+                column: "BookId",
+                principalTable: "Books",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Votes_Users_UserId",
+                table: "Votes",
+                column: "UserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Votes_VotingSessions_VotingSessionId",
+                table: "Votes",
+                column: "VotingSessionId",
+                principalTable: "VotingSessions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Votes_Books_BookId",
+                table: "Votes");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Votes_Users_UserId",
+                table: "Votes");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Votes_VotingSessions_VotingSessionId",
+                table: "Votes");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Votes",
+                table: "Votes");
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 5);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 6);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 7);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 8);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 9);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 10);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 11);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 12);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 13);
+
+            migrationBuilder.DeleteData(
+                table: "Votes",
+                keyColumn: "Id",
+                keyValue: 14);
+
+            migrationBuilder.RenameTable(
+                name: "Votes",
+                newName: "Vote");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Votes_VotingSessionId",
+                table: "Vote",
+                newName: "IX_Vote_VotingSessionId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Votes_UserId",
+                table: "Vote",
+                newName: "IX_Vote_UserId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Votes_BookId",
+                table: "Vote",
+                newName: "IX_Vote_BookId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Vote",
+                table: "Vote",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Vote_Books_BookId",
+                table: "Vote",
+                column: "BookId",
+                principalTable: "Books",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Vote_Users_UserId",
+                table: "Vote",
+                column: "UserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Vote_VotingSessions_VotingSessionId",
+                table: "Vote",
+                column: "VotingSessionId",
+                principalTable: "VotingSessions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Bookworm-Society-API/Models/BookClub.cs
+++ b/Bookworm-Society-API/Models/BookClub.cs
@@ -17,7 +17,7 @@
 
         public List<VotingSession>? VotingSessions {  get; set; }
         public List<User>? Members { get; set; }
-        public List<Book>? HaveRead {  get; set; }
+        public List<Book>? HaveRead {  get; set; } = new List<Book>();
         public List<Post>? Posts { get; set; }
 
 

--- a/Bookworm-Society-API/Models/VotingSession.cs
+++ b/Bookworm-Society-API/Models/VotingSession.cs
@@ -13,7 +13,7 @@
         public int BookClubId { get; set; }
         public BookClub BookClub { get; set; }
 
-        public List<Book>? VotingBooks {  get; set; }
+        public List<Book> VotingBooks {  get; set; }
         public List<Vote>? Votes { get; set; }
 
     }

--- a/Bookworm-Society-API/Program.cs
+++ b/Bookworm-Society-API/Program.cs
@@ -9,6 +9,8 @@ using Bookworm_Society_API.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Logging.ClearProviders(); // Optional: Remove other providers if needed
+builder.Logging.AddConsole(); // Log to the console
 
 // allows passing datetimes without time zone data 
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);

--- a/Bookworm-Society-API/Program.cs
+++ b/Bookworm-Society-API/Program.cs
@@ -48,6 +48,8 @@ builder.Services.AddScoped<IBookClubRepository, BookClubRepository>();
 
 builder.Services.AddScoped<IBaseRepository, BaseRepository>();
 
+builder.Services.AddHostedService<VotingSessionChecker>();
+
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/Bookworm-Society-API/Repositories/VoteRepository.cs
+++ b/Bookworm-Society-API/Repositories/VoteRepository.cs
@@ -1,5 +1,7 @@
 ﻿using Bookworm_Society_API.Data;
 using Bookworm_Society_API.Interfaces;
+using Bookworm_Society_API.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Bookworm_Society_API.Repositories
 {
@@ -10,6 +12,30 @@ namespace Bookworm_Society_API.Repositories
         public VoteRepository(Bookworm_SocietyDbContext context)
         {
             dbContext = context;
+        }
+        public async Task<Vote> CreateVote(Vote vote)
+        {
+            await dbContext.Votes.AddAsync(vote);
+            await dbContext.SaveChangesAsync();
+            return vote;
+        }
+        public async Task<VotingSession> GetSingleVotingSession(int votingSessionId)
+        {
+            var session = await dbContext.VotingSessions
+                .Include(vs => vs.Votes)
+                .Include(vs => vs.VotingBooks)
+                .SingleOrDefaultAsync(vs => vs.Id == votingSessionId);
+            if (session == null)
+            {
+                return null;
+            }
+            return session;
+        }
+
+
+        public async Task<bool> VotingSessionExistsAsync(int votingSessionId)
+        {
+            return await dbContext.VotingSessions.AnyAsync(vs => vs.Id == votingSessionId);
         }
     }
 }

--- a/Bookworm-Society-API/Repositories/VotingSessionRepository.cs
+++ b/Bookworm-Society-API/Repositories/VotingSessionRepository.cs
@@ -18,15 +18,33 @@ namespace Bookworm_Society_API.Repositories
         {
             var bookclub = await dbContext.BookClubs
                 .Include(bc => bc.VotingSessions)
+                    .ThenInclude(vs => vs.VotingBooks)
+                .Include(bc => bc.VotingSessions)
                     .ThenInclude(vs => vs.Votes)
                 .SingleOrDefaultAsync(bc => bc.Id == bookClubId);
 
-            if (bookclub?.VotingSessions == null || !bookclub.VotingSessions.Any()) return null;
+            if (bookclub == null || !bookclub.VotingSessions.Any())
+                return null;
+
 
             var activeVotingSessions = bookclub.VotingSessions.FirstOrDefault(vs => vs.IsActive && vs.VotingEndDate >= DateTime.Now);
             return activeVotingSessions;
             
         }
+
+        public async Task<bool> IsUserAllowedToVote(int bookClubId, int userId)
+        {
+            var bookClub = await dbContext.BookClubs
+                .Include(bc => bc.Members)
+                .Include(bc => bc.Host)
+                .SingleOrDefaultAsync(bc => bc.Id == bookClubId);
+
+            bool isHost = bookClub.Host.Id == userId;
+            bool isMember = bookClub.Members?.Any(m => m.Id == userId) == true;
+
+            return isHost || isMember;
+        }
+
         public async Task<VotingSession> CreateVotingSession(int userId, int bookClubId, List<int> bookIds)
         {
             throw new NotImplementedException();

--- a/Bookworm-Society-API/Repositories/VotingSessionRepository.cs
+++ b/Bookworm-Society-API/Repositories/VotingSessionRepository.cs
@@ -1,5 +1,7 @@
 ﻿using Bookworm_Society_API.Data;
 using Bookworm_Society_API.Interfaces;
+using Bookworm_Society_API.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Bookworm_Society_API.Repositories
 {
@@ -10,6 +12,24 @@ namespace Bookworm_Society_API.Repositories
         public VotingSessionRepository(Bookworm_SocietyDbContext context)
         {
             dbContext = context;
+        }
+
+        public async Task<VotingSession> GetLatestVotingSessionAsync(int bookClubId, int userId)
+        {
+            var bookclub = await dbContext.BookClubs
+                .Include(bc => bc.VotingSessions)
+                    .ThenInclude(vs => vs.Votes)
+                .SingleOrDefaultAsync(bc => bc.Id == bookClubId);
+
+            if (bookclub?.VotingSessions == null || !bookclub.VotingSessions.Any()) return null;
+
+            var activeVotingSessions = bookclub.VotingSessions.FirstOrDefault(vs => vs.IsActive && vs.VotingEndDate >= DateTime.Now);
+            return activeVotingSessions;
+            
+        }
+        public async Task<VotingSession> CreateVotingSession(int userId, int bookClubId, List<int> bookIds)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Bookworm-Society-API/Repositories/VotingSessionRepository.cs
+++ b/Bookworm-Society-API/Repositories/VotingSessionRepository.cs
@@ -45,9 +45,21 @@ namespace Bookworm_Society_API.Repositories
             return isHost || isMember;
         }
 
-        public async Task<VotingSession> CreateVotingSession(int userId, int bookClubId, List<int> bookIds)
+        public async Task<VotingSession> CreateVotingSession(VotingSession votingSession)
         {
-            throw new NotImplementedException();
+            await dbContext.VotingSessions.AddAsync(votingSession);
+            await dbContext.SaveChangesAsync();
+            return votingSession;
         }
+
+        public async Task<List<Book>> GetBooksByIdsAsync(List<int> bookIds)
+        {
+            var books = await dbContext.Books
+                .Where(b => bookIds.Contains(b.Id))
+                .ToListAsync();
+
+            return books;
+        }
+
     }
 }

--- a/Bookworm-Society-API/Result/Result.cs
+++ b/Bookworm-Society-API/Result/Result.cs
@@ -7,12 +7,12 @@
         public T? Data { get; set; } // Nullable data
         public ErrorType ErrorType { get; set; }
 
-        public static Result<T> SuccessResult(T data)
+        public static Result<T> SuccessResult(T data, string message = "Success")
         {
             return new Result<T>
             {
                 Success = true,
-                Message = "Success", 
+                Message = message,
                 Data = data,
                 ErrorType = ErrorType.None
             };

--- a/Bookworm-Society-API/Services/PostService.cs
+++ b/Bookworm-Society-API/Services/PostService.cs
@@ -52,7 +52,7 @@ namespace Bookworm_Society_API.Services
             if (!await _postRepository.IsUserAllowedToPost(postDto.BookClubId, postDto.UserId))
             {
                 return Result<PostDetailDTO>.FailureResult(
-                    "User is not a member or host of this book club.",
+                    "The user is not a member or the host of this book club and cannot access this feature.",
                     ErrorType.Conflict
                 );
             }

--- a/Bookworm-Society-API/Services/VoteService.cs
+++ b/Bookworm-Society-API/Services/VoteService.cs
@@ -17,34 +17,34 @@ namespace Bookworm_Society_API.Services
             _baseRepository = baseRepository;
         }
 
-        public async Task<Result<Vote>> CreateVote(CreateVoteDTO voteDTO)
+        public async Task<Result<object>> CreateVote(CreateVoteDTO voteDTO)
         {
-            if(!await _baseRepository.UserExistsAsync(voteDTO.UserId))
+          if(!await _baseRepository.UserExistsAsync(voteDTO.UserId))
             {
-                return Result<Vote>.FailureResult($"No user was found with the following id: {voteDTO.UserId}", ErrorType.NotFound);
+                return Result<object>.FailureResult($"No user was found with the following id: {voteDTO.UserId}", ErrorType.NotFound);
 
             }
 
             if (!await _baseRepository.BookExistsAsync(voteDTO.BookId))
             {
-                return Result<Vote>.FailureResult($"No book was found with the following id: {voteDTO.BookId}", ErrorType.NotFound);
+                return Result<object>.FailureResult($"No book was found with the following id: {voteDTO.BookId}", ErrorType.NotFound);
             }
 
             var votingSession = await _voteRepository.GetSingleVotingSession(voteDTO.VotingSessionId);
 
             if (votingSession == null) 
             { 
-              return Result<Vote>.FailureResult($"No voting session was found with the following id: {voteDTO.VotingSessionId}", ErrorType.NotFound);
+              return Result<object>.FailureResult($"No voting session was found with the following id: {voteDTO.VotingSessionId}", ErrorType.NotFound);
             }
             
             if (votingSession.Votes.Any(v => v.UserId == voteDTO.UserId))
             {
-                return Result<Vote>.FailureResult($"The user with an id of {voteDTO.UserId} has already voted in this voting session", ErrorType.Conflict);
+                return Result<object>.FailureResult($"The user with an id of {voteDTO.UserId} has already voted in this voting session", ErrorType.Conflict);
             }
 
             if (!votingSession.VotingBooks.Any(vb => vb.Id == voteDTO.BookId))
             {
-                return Result<Vote>.FailureResult($"The book with id {voteDTO.BookId} is not part of the current voting session.", ErrorType.Conflict);
+                return Result<object>.FailureResult($"The book with id {voteDTO.BookId} is not part of the current voting session.", ErrorType.Conflict);
             }
 
             Vote newVote = new()
@@ -56,7 +56,18 @@ namespace Bookworm_Society_API.Services
 
             var createdVote = await _voteRepository.CreateVote(newVote);
 
-            return Result<Vote>.SuccessResult(createdVote);
+            var voteObject = new
+            {
+                createdVote.Id,
+                createdVote.UserId,
+                createdVote.BookId,
+                createdVote.VotingSessionId,
+
+            };
+
+            return Result<object>.SuccessResult(voteObject);
         }
+
+
     }
 }

--- a/Bookworm-Society-API/Services/VoteService.cs
+++ b/Bookworm-Society-API/Services/VoteService.cs
@@ -1,15 +1,62 @@
 ﻿using Bookworm_Society_API.Data;
+using Bookworm_Society_API.DTOs;
 using Bookworm_Society_API.Interfaces;
+using Bookworm_Society_API.Models;
+using Bookworm_Society_API.Result;
 
 namespace Bookworm_Society_API.Services
 {
     public class VoteService : IVoteService
     {
         private readonly IVoteRepository _voteRepository;
+        private readonly IBaseRepository _baseRepository;
 
-        public VoteService(IVoteRepository voteRepository)
+        public VoteService(IVoteRepository voteRepository, IBaseRepository baseRepository)
         {
             _voteRepository = voteRepository;
+            _baseRepository = baseRepository;
+        }
+
+        public async Task<Result<Vote>> CreateVote(CreateVoteDTO voteDTO)
+        {
+            if(!await _baseRepository.UserExistsAsync(voteDTO.UserId))
+            {
+                return Result<Vote>.FailureResult($"No user was found with the following id: {voteDTO.UserId}", ErrorType.NotFound);
+
+            }
+
+            if (!await _baseRepository.BookExistsAsync(voteDTO.BookId))
+            {
+                return Result<Vote>.FailureResult($"No book was found with the following id: {voteDTO.BookId}", ErrorType.NotFound);
+            }
+
+            var votingSession = await _voteRepository.GetSingleVotingSession(voteDTO.VotingSessionId);
+
+            if (votingSession == null) 
+            { 
+              return Result<Vote>.FailureResult($"No voting session was found with the following id: {voteDTO.VotingSessionId}", ErrorType.NotFound);
+            }
+            
+            if (votingSession.Votes.Any(v => v.UserId == voteDTO.UserId))
+            {
+                return Result<Vote>.FailureResult($"The user with an id of {voteDTO.UserId} has already voted in this voting session", ErrorType.Conflict);
+            }
+
+            if (!votingSession.VotingBooks.Any(vb => vb.Id == voteDTO.BookId))
+            {
+                return Result<Vote>.FailureResult($"The book with id {voteDTO.BookId} is not part of the current voting session.", ErrorType.Conflict);
+            }
+
+            Vote newVote = new()
+            {
+                UserId = voteDTO.UserId,
+                BookId = voteDTO.BookId,
+                VotingSessionId = voteDTO.VotingSessionId,
+            };
+
+            var createdVote = await _voteRepository.CreateVote(newVote);
+
+            return Result<Vote>.SuccessResult(createdVote);
         }
     }
 }

--- a/Bookworm-Society-API/Services/VotingSessionChecker.cs
+++ b/Bookworm-Society-API/Services/VotingSessionChecker.cs
@@ -22,7 +22,9 @@ namespace Bookworm_Society_API.Services
             {
                 try
                 {
-                    using(var scope = _serviceProvider.CreateScope())
+                    _logger.LogInformation("VotingSessionChecker is executing at {Time}", DateTime.UtcNow);
+
+                    using (var scope = _serviceProvider.CreateScope())
                     {
                         var votingService = scope.ServiceProvider.GetRequiredService<IVotingSessionService>();
 
@@ -34,7 +36,7 @@ namespace Bookworm_Society_API.Services
                     _logger.LogError(ex, "An error occured with this VotingSessionCheckern");
                 }
 
-                await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+                await Task.Delay(TimeSpan.FromMinutes(2), stoppingToken);
             }
 
             _logger.LogInformation("VotingSessionChecker service is stopped");

--- a/Bookworm-Society-API/Services/VotingSessionChecker.cs
+++ b/Bookworm-Society-API/Services/VotingSessionChecker.cs
@@ -1,0 +1,43 @@
+﻿using Bookworm_Society_API.Interfaces;
+
+namespace Bookworm_Society_API.Services
+{
+    public class VotingSessionChecker : BackgroundService
+    {
+
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<VotingSessionChecker> _logger;
+
+        public VotingSessionChecker(IServiceProvider serviceProvider, ILogger<VotingSessionChecker> logger)
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("VotingSessionChecker service has started");
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using(var scope = _serviceProvider.CreateScope())
+                    {
+                        var votingService = scope.ServiceProvider.GetRequiredService<IVotingSessionService>();
+
+                        await votingService.CheckAndUpdateVotingSessionAsync(stoppingToken);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "An error occured with this VotingSessionCheckern");
+                }
+
+                await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+            }
+
+            _logger.LogInformation("VotingSessionChecker service is stopped");
+        }
+    }
+}

--- a/Bookworm-Society-API/Services/VotingSessionService.cs
+++ b/Bookworm-Society-API/Services/VotingSessionService.cs
@@ -114,7 +114,7 @@ namespace Bookworm_Society_API.Services
 
         }
 
-        public async Task CheckAndUpdateVotingSession(CancellationToken cancellationToken)
+        public async Task CheckAndUpdateVotingSessionAsync(CancellationToken cancellationToken)
         {
             
             var activeSessions = await _votingSessionRepository.GetActiveVotingSessions(cancellationToken);

--- a/Bookworm-Society-API/Services/VotingSessionService.cs
+++ b/Bookworm-Society-API/Services/VotingSessionService.cs
@@ -1,15 +1,51 @@
 ﻿using Bookworm_Society_API.Data;
 using Bookworm_Society_API.Interfaces;
+using Bookworm_Society_API.Models;
+using Bookworm_Society_API.Result;
 
 namespace Bookworm_Society_API.Services
 {
     public class VotingSessionService : IVotingSessionService
     {
         private readonly IVotingSessionRepository _votingSessionRepository;
+        private readonly IBaseRepository _baseRepository;
 
-        public VotingSessionService(IVotingSessionRepository votingSessionRepository)
+        public VotingSessionService(IVotingSessionRepository votingSessionRepository, IBaseRepository baseRepository)
         {
             _votingSessionRepository = votingSessionRepository;
+            _baseRepository = baseRepository;
+        }
+
+        public async Task<Result<VotingSession?>> GetLatestVotingSessionAsync(int bookClubId, int userId)
+        {
+            if (!await _baseRepository.UserExistsAsync(userId))
+            {
+                return Result<VotingSession>.FailureResult($"Not user was found with the following id: {userId}", ErrorType.NotFound);
+            }
+
+            if (!await _baseRepository.BookClubExistsAsync(bookClubId))
+            {
+                return Result<VotingSession>.FailureResult($"Not book club was found with the following id: {bookClubId}", ErrorType.NotFound);
+            }
+
+            var votingsession = await _votingSessionRepository.GetLatestVotingSessionAsync(bookClubId, userId);
+
+            // this should be a different like .NoContent
+            if (votingsession == null)
+            {
+                return Result<VotingSession?>.SuccessResult(null, "No active voting session");
+            }
+
+            if (votingsession.Votes.Any(v => v.UserId == userId))
+            {
+                return Result<VotingSession?>.SuccessResult( null,"You have already voted in this voting session");
+            }
+
+            return Result<VotingSession>.SuccessResult(votingsession);
+        }
+        public async Task<Result<VotingSession>> CreateVotingSession(int userId, int bookClubId, List<int> bookIds)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Bookworm-Society-API/Services/VotingSessionService.cs
+++ b/Bookworm-Society-API/Services/VotingSessionService.cs
@@ -113,5 +113,21 @@ namespace Bookworm_Society_API.Services
 
 
         }
+
+        public async Task CheckAndUpdateVotingSession(CancellationToken cancellationToken)
+        {
+            
+            var activeSessions = await _votingSessionRepository.GetActiveVotingSessions(cancellationToken);
+
+            foreach (var session in activeSessions)
+            {
+                if(session.VotingEndDate <= DateTime.UtcNow)
+                {
+                    await _votingSessionRepository.FinalizeVotingSessionAsync(session.Id, cancellationToken);
+
+                }
+            }
+
+        }
     }
 }


### PR DESCRIPTION
﻿## Detailed Description
<!--- Explain **what** was changed and **why** -->
<!--- Why is this change required? What problem does it solve? -->
Added all the endpoints needed in order for voting sessions to work. They all have error handling to deal with situations where a user cant vote in that club or maybe has already voted. I added a background service which is essentially a long-running task that runs independently of the request-response lifecycle that we are use to using with our HTTP requests. 

## Related Issues
#30 
#31
 #19
#32 
#29 

## How to Test
<!--- Step-by-step instructions for testing your changes. -->
<!--- Include any necessary setup steps, commands to run, or test cases. -->
1.  Go into your pgAdmin and create a voting session. Make sure to select books to be voted on by adding it to the respective table. 
2. In the voest table add some votes that correspond to the ids of the books being voteD on. 
3. After you've done all that this is what you need to test.
- The booksclubs book id get updated with the book with the most votes. 
- The have read gets a new row with the ids to the bookclub and it's previoud book obj id
- the voting session goes from isActive: true to false. It's winningBookId gets updated with the book that won
4. After this you can also check scenarioes where their is a tie. If this happens the books get selected at random. 
5. Lastly check what happens if there are no votes. Currently I have it set up to select the first book in the books to vote on list.



## Screenshots (if applicable)

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [ x] ✨ New feature
- [ ] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation

## 💬 Additional Notes
<!--- Add any other context, discussions, or considerations regarding this PR. -->
