### PR TITLE
Fix/repo and date storage

### DIFF
--- a/Bookworm-Society-API/Interfaces/IBookClubRepository.cs
+++ b/Bookworm-Society-API/Interfaces/IBookClubRepository.cs
@@ -11,7 +11,7 @@ namespace Bookworm_Society_API.Interfaces
         Task<BookClub> UpdateBookClubAsync(BookClub bookClub, int bookClubId);
         Task<BookClub> DeleteBookClubAsync(int bookClubId);
         Task<BookClub> GetABookClubHaveReadAsync(int bookClubId);
-        Task<BookClub> GetABookClubHavePostAsync(int bookClubId);
+        Task<BookClub> GetABookClubPostsAsync(int bookClubId);
         Task<BookClub> AddUserToBookClubAsync(BookClub bookClub, int userId);
         Task<BookClub> RemoveUserFromBookClubAsync(BookClub bookClub, int userId);
 

--- a/Bookworm-Society-API/Repositories/BookClubRepository.cs
+++ b/Bookworm-Society-API/Repositories/BookClubRepository.cs
@@ -30,10 +30,7 @@ namespace Bookworm_Society_API.Repositories
                 .Include(bc => bc.Book)
                 .Include(bc => bc.Members)
                 .SingleOrDefaultAsync(bc => bc.Id == bookClubId);
-            if (bookClub == null)
-            {
-                return null;
-            }
+           
             return bookClub;
          }
 
@@ -74,7 +71,7 @@ namespace Bookworm_Society_API.Repositories
         public async Task<BookClub> DeleteBookClubAsync(int bookClubId)
             {
                 var bookClubToDelete = await dbContext.BookClubs.SingleOrDefaultAsync(bc => bc.Id == bookClubId);
-                
+
                 if (bookClubToDelete == null)
                 {
                     return null;
@@ -92,14 +89,9 @@ namespace Bookworm_Society_API.Repositories
                 .Include(bc => bc.HaveRead)
                 .SingleOrDefaultAsync(bc => bc.Id == bookClubId);
 
-            if (bookClub == null)
-            {
-                return null;
-            }
-
             return bookClub;
         }
-        public async Task<BookClub> GetABookClubHavePostAsync(int bookClubId)
+        public async Task<BookClub> GetABookClubPostsAsync(int bookClubId)
         {
             var bookClub = await dbContext.BookClubs
                 .Include(bc => bc.Posts)

--- a/Bookworm-Society-API/Repositories/BookRepository.cs
+++ b/Bookworm-Society-API/Repositories/BookRepository.cs
@@ -25,10 +25,6 @@ namespace Bookworm_Society_API.Repositories
                 .ThenInclude(r => r.User)
                 .SingleOrDefaultAsync(b => b.Id == bookId);
 
-            if (book == null)
-            {
-                return null;
-            }
 
             return book;
 

--- a/Bookworm-Society-API/Repositories/CommentRepository.cs
+++ b/Bookworm-Society-API/Repositories/CommentRepository.cs
@@ -25,7 +25,7 @@ namespace Bookworm_Society_API.Repositories
         {
             var commentToDelete = await dbContext.Comments.SingleOrDefaultAsync(c => c.Id == commentId);
 
-            if (commentToDelete == null)
+            if (commentToDelete == null) 
             {
                 return null;
             }

--- a/Bookworm-Society-API/Repositories/PostRepository.cs
+++ b/Bookworm-Society-API/Repositories/PostRepository.cs
@@ -23,10 +23,7 @@ namespace Bookworm_Society_API.Repositories
                 .ThenInclude(c => c.User)
                 .Include(p => p.User)
                 .SingleOrDefaultAsync(p => p.Id == postId);
-            if (post == null)
-            {
-                return null;
-            }
+            
             return post;
         }
         public async Task<Post> CreatePostAsync(Post post)
@@ -38,10 +35,12 @@ namespace Bookworm_Society_API.Repositories
         public async Task<Post> UpdatePostAsync(Post post, int postId)
         {
             var postToUpdate = await dbContext.Posts.SingleOrDefaultAsync(p => p.Id == postId);
+
             if (postToUpdate == null)
             {
                 return null;
             }
+            
 
             postToUpdate.Content = post.Content;
             postToUpdate.IsEdited = true;
@@ -53,11 +52,9 @@ namespace Bookworm_Society_API.Repositories
         public async Task<Post> DeletePostAsync(int postId)
         {
             var postToDelete = await dbContext.Posts.SingleOrDefaultAsync(p => p.Id == postId);
-            
+
             if (postToDelete == null)
-            {
                 return null;
-            }
 
             dbContext.Posts.Remove(postToDelete);
 

--- a/Bookworm-Society-API/Repositories/ReviewRepository.cs
+++ b/Bookworm-Society-API/Repositories/ReviewRepository.cs
@@ -31,6 +31,7 @@ namespace Bookworm_Society_API.Repositories
                 return null;
             }
 
+
             reviewToUpdate.Content = review.Content;
             reviewToUpdate.Rating = review.Rating;
 
@@ -42,9 +43,7 @@ namespace Bookworm_Society_API.Repositories
             var reviewToDelete = await dbContext.Reviews.SingleOrDefaultAsync(r => r.Id == reviewId);
 
             if (reviewToDelete == null)
-            {
                 return null;
-            }
 
             dbContext.Reviews.Remove(reviewToDelete);
             await dbContext.SaveChangesAsync();

--- a/Bookworm-Society-API/Repositories/UserRepository.cs
+++ b/Bookworm-Society-API/Repositories/UserRepository.cs
@@ -19,10 +19,6 @@ namespace Bookworm_Society_API.Repositories
             User user = await dbContext.Users
                 .SingleOrDefaultAsync(u => u.Id == userId);
             
-            if (user == null)
-            {
-                return null;
-            }
             return user;
         }
 
@@ -54,11 +50,6 @@ namespace Bookworm_Society_API.Repositories
         public async Task<User?> CheckUserAsync(string userUid)
         {
             var user =  await dbContext.Users.FirstOrDefaultAsync(u => u.Uid == userUid);
-
-            if (user == null) 
-            { 
-                return null;
-            } 
 
             return user;
         }

--- a/Bookworm-Society-API/Repositories/VoteRepository.cs
+++ b/Bookworm-Society-API/Repositories/VoteRepository.cs
@@ -25,10 +25,7 @@ namespace Bookworm_Society_API.Repositories
                 .Include(vs => vs.Votes)
                 .Include(vs => vs.VotingBooks)
                 .SingleOrDefaultAsync(vs => vs.Id == votingSessionId);
-            if (session == null)
-            {
-                return null;
-            }
+            
             return session;
         }
 

--- a/Bookworm-Society-API/Repositories/VotingSessionRepository.cs
+++ b/Bookworm-Society-API/Repositories/VotingSessionRepository.cs
@@ -86,7 +86,7 @@ namespace Bookworm_Society_API.Repositories
                 .AsSplitQuery()
                 .SingleOrDefaultAsync(vs => vs.Id == votingSessionId, cancellationToken);
 
-            if (session.VotingEndDate <= DateTime.UtcNow)
+            if (session.VotingEndDate <= DateTime.Now)
             {
                 session.IsActive = false;
 

--- a/Bookworm-Society-API/Services/BookClubService.cs
+++ b/Bookworm-Society-API/Services/BookClubService.cs
@@ -122,7 +122,7 @@ namespace Bookworm_Society_API.Services
         }
         public async Task<Result<object>> GetABookClubPostAsync(int bookClubId)
         {
-            var bookclub = await _bookClubRepository.GetABookClubHavePostAsync(bookClubId);
+            var bookclub = await _bookClubRepository.GetABookClubPostsAsync(bookClubId);
 
             if (bookclub == null)
             {

--- a/Bookworm-Society-API/Services/VotingSessionChecker.cs
+++ b/Bookworm-Society-API/Services/VotingSessionChecker.cs
@@ -22,7 +22,7 @@ namespace Bookworm_Society_API.Services
             {
                 try
                 {
-                    _logger.LogInformation("VotingSessionChecker is executing at {Time}", DateTime.UtcNow);
+                    _logger.LogInformation("VotingSessionChecker is executing at {Time}", DateTime.Now);
 
                     using (var scope = _serviceProvider.CreateScope())
                     {

--- a/Bookworm-Society-API/Services/VotingSessionService.cs
+++ b/Bookworm-Society-API/Services/VotingSessionService.cs
@@ -121,7 +121,7 @@ namespace Bookworm_Society_API.Services
 
             foreach (var session in activeSessions)
             {
-                if(session.VotingEndDate <= DateTime.UtcNow)
+                if(session.VotingEndDate <= DateTime.Now)
                 {
                     await _votingSessionRepository.FinalizeVotingSessionAsync(session.Id, cancellationToken);
 


### PR DESCRIPTION
﻿## Detailed Description
<!--- Explain **what** was changed and **why** -->
<!--- Why is this change required? What problem does it solve? -->
- [ ] I was going to initially change all my DateTime.Now to Utc because form my research it's best practice and universal which allows for potential app expansion. I had an issue in the FE that didn't allow for me to capture the users local time after using new Date. After working on this for hours I reverted back to using DateTime.Now for every method including the voting session finalization. 
- [ ] Within the repository layer I was returning null to the service layer even though I was using SingleOrDefault which returns null regardless. I then realized that my code was redundant and so I went forward with removing the " `if ( blank == null) return null;`" from my repository layer. This was a good lesson though because after testing the endpoints I then found that I still need to return null in the instances where I'm further manipulating the data in some way. So that left me only removing "return null" when I wasn't manipulating the data in any way, typically in my GET calls. 

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ x] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation

## 💬 Additional Notes
<!--- Add any other context, discussions, or considerations regarding this PR. -->
